### PR TITLE
refactor: else if to switch statement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
         type: "paragraph",
         content: [
           {
-            // this mean line break
+            // this means line break
             type: "hardBreak",
             attrs: {
               text: "\n",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { lexer, MarkedToken, Token } from "marked";
+import { lexer, Token } from "marked";
 import typia from "typia";
 import { codeBlock } from "./codeBlock";
 import { heading } from "./heading";
 import { isMarkedToken } from "./IsMarkedToken";
-import { mideaSingle } from "./mediaSingle";
+import { mediaSingle } from "./mediaSingle";
 import { rule } from "./rule";
 import { text } from "./text";
 import { IJiraService, ListItemNode, ListNode } from "./type";
@@ -17,7 +17,7 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
   }
 
   switch (target.type) {
-    case "blockquote":{
+    case "blockquote": {
       const transformed = transform({ tokens: target.tokens });
       if (typia.is<IJiraService.BlockquoteNode["content"]>(transformed)) {
         return { type: "blockquote", content: transformed } satisfies IJiraService.BlockquoteNode;
@@ -35,7 +35,7 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
       return text({ text: target.text, marks: [{ type: "code" }] });
     }
     case "def": {
-    // 링크 정의에 해당하나 각 링크 별로 흩어지는 게 맞는 듯 하다.
+      // 링크 정의에 해당하나 각 링크 별로 흩어지는 게 맞는 듯 하다.
       return null;
     }
     case "del": {
@@ -65,7 +65,7 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
       return text({ text: target.text });
     }
     case "image": {
-      return mideaSingle({ url: target.href });
+      return mediaSingle({ url: target.href });
     }
     case "link": {
       return text({
@@ -76,13 +76,15 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
     case "list": {
       return {
         type: target.ordered ? "orderedList" : "bulletList",
-        content: target.items.map((item) => {
-          const transformed = transform({ tokens: item.tokens, convertParagraph: true })
-          if (typia.is<ListItemNode["content"]>(transformed)) {
-            return { type: "listItem", content: transformed } satisfies ListItemNode;
-          }
-          return null;
-        }).filter((el) => el !== null),
+        content: target.items
+          .map((item) => {
+            const transformed = transform({ tokens: item.tokens, convertParagraph: true });
+            if (typia.is<ListItemNode["content"]>(transformed)) {
+              return { type: "listItem", content: transformed } satisfies ListItemNode;
+            }
+            return null;
+          })
+          .filter((el) => el !== null),
       } satisfies ListNode;
     }
     case "list_item": {
@@ -168,13 +170,13 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
                       transformed,
                     })
                   );
-  
+
                   return null;
                 }
               }) as any[],
             };
           }),
-        ]
+        ],
       } satisfies IJiraService.TableNode;
     }
     case "text": {
@@ -188,8 +190,8 @@ function _transform(options: { token: Token; convertParagraph?: boolean }): Jira
             },
           ],
         } satisfies IJiraService.ParagraphNode;
-      } 
-      
+      }
+
       return {
         type: "text",
         text: target.raw,

--- a/src/mediaSingle.ts
+++ b/src/mediaSingle.ts
@@ -2,6 +2,6 @@ import { tags } from "typia";
 import { media } from "./media";
 import { IJiraService } from "./type";
 
-export function mideaSingle(input: { url: string & tags.Format<"iri"> }): IJiraService.MediaSingleNode {
+export function mediaSingle(input: { url: string & tags.Format<"iri"> }): IJiraService.MediaSingleNode {
   return { type: "mediaSingle", content: [media(input)], attrs: { layout: "center" } };
 }


### PR DESCRIPTION
This pull request refactors the `_transform` function in `src/index.ts` to replace a series of `if-else` statements with a `switch` statement for better readability and maintainability. It also includes minor adjustments to the handling of specific cases within the function.

### Refactoring for improved readability:

* Replaced the `if-else` chain with a `switch` statement in the `_transform` function, making the code easier to follow and maintain. Each case now handles a specific token type, improving structure and clarity.

### Adjustments to specific token handling:

* Updated the handling of `table` tokens by replacing `targetMarkedToken.rows` with `target.rows` for consistency and readability.
* Fixed the formatting of the `table` node's `content` array, ensuring proper indentation and alignment.

### Additional improvements:

* Added a `default` case to the `switch` statement to enforce exhaustive type checking, ensuring that all token types are explicitly handled or flagged as unsupported.