### PR TITLE
fix: package lock name and package.json license field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "markdown-to-adf",
+  "name": "@wrtnlabs/markdown-to-adf",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "markdown-to-adf",
+      "name": "@wrtnlabs/markdown-to-adf",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "author": "kakasoo",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "rimraf": "^6.0.1",
     "ts-patch": "^3.3.0",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the project's license from "ISC" to "MIT" to reflect a new licensing choice.